### PR TITLE
feature-erms-3055

### DIFF
--- a/server/gokbg3/grails-app/services/com/k_int/ESSearchService.groovy
+++ b/server/gokbg3/grails-app/services/com/k_int/ESSearchService.groovy
@@ -473,7 +473,7 @@ class ESSearchService{
     }
     else{
       SearchScrollRequest scrollRequest = new SearchScrollRequest(params.scrollId)
-      scrollRequest.scroll("1m")
+      scrollRequest.scroll("5m")
       response = esClient.searchScroll(scrollRequest)
       try{
         if (params.lastPage && Integer.valueOf(params.lastPage) > -1){


### PR DESCRIPTION
for ERMS-3055 (the LAS:eR-side sync refactor), the scroll timeout has been set to 5 minutes in order to prevent context mismatches